### PR TITLE
Azure vnet flow logs support in powershell script

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@kentik/eng-cloud

--- a/azure-setup.ps1
+++ b/azure-setup.ps1
@@ -174,29 +174,6 @@ else {
 }
 Write-Output ""
 
-# Ensure network watcher feature is registered
-# Network Watcher feature is registered by default and will be in 'Registering' state shortly after sub creation.
-Write-Output "Ensuring network watcher feature is registered."
-$nwRet = Get-AzProviderFeature -FeatureName AllowNetworkWatcher -ProviderNamespace Microsoft.Network
-
-if ($nwRet.RegistrationState -eq 'NotRegistered') {
-    Register-AzProviderFeature -FeatureName AllowNetworkWatcher -ProviderNamespace Microsoft.Network
-    Write-Output "Network Watcher feature is being registered. Please be patient, this may take several minutes."
-
-    # Wait for the feature to be registered
-    do {
-        Start-Sleep -Milliseconds 5000
-        $nwRet = Get-AzProviderFeature -FeatureName AllowNetworkWatcher -ProviderNamespace Microsoft.Network
-        Write-Output "Checking registration status..."
-    } while ($nwRet.RegistrationState -eq 'NotRegistered')
-
-    Write-Output "Success: Network Watcher feature is now registered."
-}
-else {
-    Write-Output "Success: Network Watcher feature is already registered."
-}
-Write-Output ""
-
 # Ensure the network watcher feature is enabled for the resource group and location
 # By default, Network Watcher is automatically enabled.
 # When you create or update a virtual network in your subscription, Network Watcher will be automatically enabled in your Virtual Network's region.

--- a/azure-setup.ps1
+++ b/azure-setup.ps1
@@ -221,7 +221,7 @@ Get-AzVirtualNetwork -ResourceGroupName $resourceGroup | ForEach-Object {
         $existingFlowLog = $existingFlowLogs | Where-Object { $_.TargetResourceId -eq $VNet.Id }
 
         if ($existingFlowLog -and $existingFlowLog.Enabled) {
-            Write-Output "Success: VNet flow logs already exist for Virtual Network '$($VNet.Name)' with Name: $($existingFlowLog.Name)"
+            Write-Output "Success: VNet flow logs already exist for Virtual Network '$($VNet.Name)' with Name: '$($existingFlowLog.Name)'"
         }
         else {
             # Enable VNet flow logs
@@ -229,7 +229,7 @@ Get-AzVirtualNetwork -ResourceGroupName $resourceGroup | ForEach-Object {
             Write-Output "Enabling VNet flow logs for Virtual Network '$($VNet.Name)'"
             $ret = New-AzNetworkWatcherFlowLog -Enabled $true -Name "flowLog_$($VNet.Name)" -NetworkWatcherName "NetworkWatcher_$location" -ResourceGroupName NetworkWatcherRG -StorageId $storageAccountID -TargetResourceId $VNet.Id -FormatVersion 2 -EnableRetention $true -RetentionPolicyDays 7
             if ( $ret.TargetResourceId.toLower().length -ne 0 -AND $ret.Enabled ) {
-                Write-Output "Success: VNet flow logs are enabled with Name: $($ret.Name)"
+                Write-Output "Success: VNet flow logs are enabled with Name: '$($ret.Name)'"
             }
             else {
                 Write-Error "Fail: Could not enable VNet flow logs"

--- a/azure-setup.ps1
+++ b/azure-setup.ps1
@@ -175,11 +175,11 @@ else {
 Write-Output ""
 
 # Ensure network watcher feature is registered
-# Network Watcher feature is registered by default
+# Network Watcher feature is registered by default and will be in 'Registering' state shortly after sub creation.
 Write-Output "Ensuring network watcher feature is registered."
 $nwRet = Get-AzProviderFeature -FeatureName AllowNetworkWatcher -ProviderNamespace Microsoft.Network
 
-if ($nwRet.RegistrationState -ne 'Registered') {
+if ($nwRet.RegistrationState -eq 'NotRegistered') {
     Register-AzProviderFeature -FeatureName AllowNetworkWatcher -ProviderNamespace Microsoft.Network
     Write-Output "Network Watcher feature is being registered. Please be patient, this may take several minutes."
 
@@ -188,7 +188,7 @@ if ($nwRet.RegistrationState -ne 'Registered') {
         Start-Sleep -Milliseconds 5000
         $nwRet = Get-AzProviderFeature -FeatureName AllowNetworkWatcher -ProviderNamespace Microsoft.Network
         Write-Output "Checking registration status..."
-    } while ($nwRet.RegistrationState -ne 'Registered')
+    } while ($nwRet.RegistrationState -eq 'NotRegistered')
 
     Write-Output "Success: Network Watcher feature is now registered."
 }

--- a/azure-setup.ps1
+++ b/azure-setup.ps1
@@ -3,7 +3,18 @@ $subscriptionID = "a8f472b9-6b5a-48fe-806d-a3ca4e2d1f6f"
 $resourceGroup = "asdf"
 $storageAccount = "asdfasdfas"
 $location = "australiacentral"
+
+class EnrichmentScope {
+    [string]$SubscriptionID
+    [string[]]$ResourceGroupNames
+}
+
+$enrichmentScopes = @()
 #############################################
+
+# set the subscription context
+Set-AzContext -Subscription $subscriptionID
+Write-Output ""
 
 $ErrorActionPreference = "Stop"
 
@@ -12,7 +23,8 @@ Write-Output "Verifying subscription ID '$subscriptionID"
 $ret = Get-AzSubscription -SubscriptionId $subscriptionID -ErrorAction SilentlyContinue
 if ( $ret.ID.Length -eq 0 ) {
     Write-Error "Fail: Could not find subscriptionID '$subscriptionID'"
-} else {
+}
+else {
     Write-Output "Success: verified subscription ID"
 }
 Write-Output ""
@@ -27,7 +39,8 @@ Get-AzLocation | ForEach-Object {
 }
 if ( -NOT $foundLocation ) {
     Write-Error "Fail: Could not find location '$location"
-} else {
+}
+else {
     Write-Output "Success: Location verified"
 }
 Write-Output ""
@@ -37,17 +50,19 @@ Write-Output "Verifying resource group '$resourceGroup'"
 $ret = Get-AzResourceGroup -Name $resourceGroup -ErrorAction SilentlyContinue
 if ( $ret.ResourceGroupName.length -eq 0 ) {
     Write-Error "Fail: Could not find resource group '$resourceGroup'"
-} else {
+}
+else {
     Write-Output "Success: Resource group verified"
 }
 Write-Output ""
 
 # Verify the subscription has a service principal for the Kentik app
-Write-Output "Ensuring Kentik service principal 'a20ce222-63c0-46db-86d5-58551eeee89f' exists"
-$ret = Get-AzADServicePrincipal -ApplicationID "a20ce222-63c0-46db-86d5-58551eeee89f"
+Write-Output "Ensuring Kentik service principal a20ce222-63c0-46db-86d5-58551eeee89f exists"
+$ret = Get-AzADServicePrincipal -ApplicationID a20ce222-63c0-46db-86d5-58551eeee89f
 if ( $ret.DisplayName.length -eq 0 ) {
     Write-Error "Fail: Could not find the service principal"
-} else {
+}
+else {
     $appPrincipalID = $ret.Id
     $kentikPrincipalName = $ret.DisplayName
     Write-Output "Success: service principal found with ID '$appPrincipalID', display name '$kentikPrincipalName'"
@@ -61,30 +76,78 @@ if ( $ret.RoleDefinitionName.length -eq 0 ) {
     $ret = New-AzRoleAssignment -ObjectId $appPrincipalID -ResourceGroupName $resourceGroup -RoleDefinitionName Reader
     if ( $ret.RoleDefinitionName.length -gt 0 -AND $ret.RoleDefinitionName.toLower().equals("reader") ) {
         Write-Output "Success: Access granted"
-    } else {
+    }
+    else {
         Write-Error "Fail: Could not grant access"
     }
-} else {
+}
+else {
     Write-Output "Success: Access was already granted"
 }
 Write-Output ""
+
+# Verify service principal has Reader access to enrichment subscriptions and resource groups
+Foreach ($enrichmentScope in $enrichmentScopes) {
+    if ($enrichmentScope.ResourceGroupNames.length -eq 0 ) {
+        # Verify subscription Reader role
+        $subscriptionScope = "/subscriptions/" + $enrichmentScope.SubscriptionID
+        Write-Output "Ensuring service principal '$kentikPrincipalName' has Reader access to '$subscriptionScope'"
+        $ret = Get-AzRoleAssignment -ObjectId $appPrincipalID -Scope $subscriptionScope -RoleDefinitionName Reader
+        if ( $ret.Scope -eq $subscriptionScope ) {
+            Write-Output "Success: Access was already granted to subscription scope: " + $subscriptionScope
+        }
+        else {
+            Write-Output "Reader role not found. Creating new role"
+            $ret = New-AzRoleAssignment -ObjectId $appPrincipalID -Scope $subscriptionScope -RoleDefinitionName Reader
+            if ( $ret.Scope -eq $subscriptionScope ) {
+                Write-Output "Success: Access granted"
+            }
+            else {
+                Write-Error "Fail: Could not grant Reader role to $subscriptionScope"
+            }
+        }
+    }
+    else {
+        # Verify individual resource group reader roles
+        Foreach ($enrichmentResourceGroupName in $enrichmentscope.ResourceGroupNames) {
+            $resourceGroupScope = "/subscriptions/" + $enrichmentScope.SubscriptionID + "/resourceGroups/" + $enrichmentResourceGroupName
+            Write-Output "Ensuring service principal '$kentikPrincipalName' has Reader access to '$resourceGroupScope'"
+            $ret = Get-AzRoleAssignment -ObjectId $appPrincipalID -Scope $resourceGroupScope -RoleDefinitionName Reader
+            if ( $ret.length -gt 0 ) {
+                Write-Output "Success: Access was already granted"
+            }
+            else {
+                Write-Output "Reader role not found. Creating new role"
+                $ret = New-AzRoleAssignment -ObjectId $appPrincipalID -Scope "$resourceGroupScope" -RoleDefinitionName Reader
+                if ( $ret.Scope -eq $resourceGroupScope ) {
+                    Write-Output "Success: Access granted"
+                }
+                else {
+                    Write-Error "Fail: Could not grant Reader role to $resourceGroupScope"
+                }
+            }
+        }
+    }
+}
 
 # Verify storage account
 $storageAccount = $storageAccount.toLower()
 Write-Output "Ensuring storage account '$storageAccount' in resource group '$resourceGroup', location '$location'"
 $ret = Get-AzStorageAccount -ResourceGroupName $resourceGroup -Name $storageAccount -ErrorAction SilentlyContinue
 $storageAccountID = $ret.ID
-if ( $ret.ProvisioningState -ne [Microsoft.Azure.Management.Network.Models.ProvisioningState]::Succeeded ) {
+if ( $ret.ProvisioningState -ne 'Succeeded' ) {
     # Create storage account
     Write-Output "Storage account does not yet exist - creating it now"
     $ret = New-AzStorageAccount -ResourceGroupName $resourceGroup -Name $storageAccount -Location $location -SkuName Standard_LRS -Kind StorageV2
-    if ( $ret.ResourceGroupName.toLower().equals($resourceGroup.toLower()) ){
+    if ( $ret.ResourceGroupName.toLower().equals($resourceGroup.toLower()) ) {
         $storageAccountID = $ret.ID
         Write-Output "Success: Created storage account"
-    } else {
+    }
+    else {
         Write-Error "Fail: Could not create storage account"
     }
-} else {
+}
+else {
     if ( -NOT $ret.Location.toLower().equals($location.toLower()) ) {
         Write-Error "Fail: storage account '$storageAccount' found, but in location '$($ret.Location)'. Must be in location '$location'"
     }
@@ -101,43 +164,57 @@ if ( $ret.RoleDefinitionName.length -eq 0 ) {
     $ret = New-AzRoleAssignment -ObjectId $appPrincipalID -ResourceGroupName $resourceGroup -ResourceType "Microsoft.Storage/storageAccounts" -ResourceName $storageAccount -RoleDefinitionName Contributor
     if ( $ret.RoleDefinitionName.length -gt 0 -AND $ret.RoleDefinitionName.toLower().equals("contributor") ) {
         Write-Output "Success: Access granted"
-    } else {
+    }
+    else {
         Write-Error "Fail: Could not grant access"
     }
-} else {
+}
+else {
     Write-Output "Success: Access was already granted"
 }
 Write-Output ""
 
-# Enable network watcher feature is registered
-Write-Output "Ensuring network watcher feature is registered. Please be patient, this may take several minutes"
-$nwRet = Register-AzProviderFeature -FeatureName AllowNetworkWatcher -ProviderNamespace Microsoft.Network
-While ( $nwRet.RegistrationState.toLower().equals("registering") ) {
-    $nwRet = Get-AzProviderFeature -FeatureName AllowNetworkWatcher -ProviderNamespace Microsoft.Network
-    $nwState = $nwRet.RegistrationState
-    Write-Output "Network watcher registration state: '$nwState'"
-    Start-Sleep -Milliseconds 5000
+# Ensure network watcher feature is registered
+# Network Watcher feature is registered by default
+Write-Output "Ensuring network watcher feature is registered."
+$nwRet = Get-AzProviderFeature -FeatureName AllowNetworkWatcher -ProviderNamespace Microsoft.Network
+
+if ($nwRet.RegistrationState -ne 'Registered') {
+    Register-AzProviderFeature -FeatureName AllowNetworkWatcher -ProviderNamespace Microsoft.Network
+    Write-Output "Network Watcher feature is being registered. Please be patient, this may take several minutes."
+
+    # Wait for the feature to be registered
+    do {
+        Start-Sleep -Milliseconds 5000
+        $nwRet = Get-AzProviderFeature -FeatureName AllowNetworkWatcher -ProviderNamespace Microsoft.Network
+        Write-Output "Checking registration status..."
+    } while ($nwRet.RegistrationState -ne 'Registered')
+
+    Write-Output "Success: Network Watcher feature is now registered."
 }
-if ( $nwRet.RegistrationState.toLower().equals("registered") ) {
-    Write-Output "Success! NetworkWatcher is registered"
-} else {
-    Write-Error "Fail: NetworkWatcher could not be registered"
+else {
+    Write-Output "Success: Network Watcher feature is already registered."
 }
 Write-Output ""
 
 # Ensure the network watcher feature is enabled for the resource group and location
+# By default, Network Watcher is automatically enabled.
+# When you create or update a virtual network in your subscription, Network Watcher will be automatically enabled in your Virtual Network's region.
+# https://learn.microsoft.com/en-us/azure/network-watcher/network-watcher-create?tabs=powershell
 Write-Output "Ensuring network watcher for resource group '$resourceGroup', location '$location'"
 $ret = Get-AzNetworkWatcher -Location $location -ErrorAction SilentlyContinue
 $networkWatcherObj = $ret
 if ( $ret.ProvisioningState.length -eq 0 -OR -Not $ret.ProvisioningState.toLower().equals("succeeded") ) {
-    $ret = New-AzNetworkWatcher -Name "nw_$($location)" -ResourceGroupName $resourceGroup -Location $location
+    $ret = New-AzNetworkWatcher -Name "NetworkWatcher_$($location)" -ResourceGroupName $resourceGroup -Location $location
     if ( -Not $ret.Name.equals("") ) {
         $networkWatcherObj = $ret
         Write-Output "Success: Network watcher created"
-    } else {
+    }
+    else {
         Write-Error "Fail: Could not create network watcher"
     }
-} else {
+}
+else {
     $networkWatcherObj = $ret
     Write-Output "Success: Network watcher already exists"
 }
@@ -154,28 +231,37 @@ Do {
 Write-Output "Success: Microsoft Insights provider is registered"
 Write-Output ""
 
-# Turn on v2 flow logs for every network security group in the resource group and region
-Write-Output "Looking for network security groups in resource group '$resourceGroup'"
-Write-Output ""
-Get-AzNetworkSecurityGroup -ResourceGroupName $resourceGroup | ForEach-Object {
-    $NSG = $_
-    if ( $NSG.Location.length -gt 0 -AND $NSG.Location.toLower().equals($location.toLower())) {
-        Write-Output "Found network security group '$($NSG.Name)' in location '$location'"
+# Add VNet support
+Write-Output "Looking for Virtual Networks (VNets) in resource group '$resourceGroup'"
+Get-AzVirtualNetwork -ResourceGroupName $resourceGroup | ForEach-Object {
+    $VNet = $_
+    if ($VNet.Location.length -gt 0 -AND $VNet.Location.toLower().equals($location.toLower())) {
+        Write-Output "Found Virtual Network '$($VNet.Name)' in location '$location'"
 
-        # Enable flow logs for this NSG
-        Write-Output "Enabling v2 flow logs in network security group '$($NSG.Name)'"
-        $ret = Set-AzNetworkWatcherConfigFlowLog -RetentionInDays 2 -NetworkWatcher $networkWatcherObj -TargetResourceId $NSG.Id -StorageAccountId $storageAccountID -EnableFlowLog $true -FormatType Json -FormatVersion 2
-        if ( $ret.TargetResourceId.toLower().length -ne 0 -AND $ret.Enabled ) {
-            Write-Output "Success: Network security group flow logs are enabled"
-        } else {
-            Write-Error "Fail: Could not enable network security group flow logs"
+        # Check if VNet flow logs are already enabled
+        Write-Output "Checking if VNet flow logs are already enabled for Virtual Network '$($VNet.Name)'"
+        $existingFlowLogs = Get-AzNetworkWatcherFlowLog -NetworkWatcherName "NetworkWatcher_$location" -ResourceGroupName "NetworkWatcherRG" -ErrorAction SilentlyContinue
+        $existingFlowLog = $existingFlowLogs | Where-Object { $_.TargetResourceId -eq $VNet.Id }
+
+        if ($existingFlowLog -and $existingFlowLog.Enabled) {
+            Write-Output "Success: VNet flow logs already exist for Virtual Network '$($VNet.Name)' with Name: $($existingFlowLog.Name)"
+        }
+        else {
+            # Enable VNet flow logs
+            # https://learn.microsoft.com/en-us/azure/network-watcher/vnet-flow-logs-powershell
+            Write-Output "Enabling VNet flow logs for Virtual Network '$($VNet.Name)'"
+            $ret = New-AzNetworkWatcherFlowLog -Enabled $true -Name "flowLog_$($VNet.Name)" -NetworkWatcherName "NetworkWatcher_$location" -ResourceGroupName NetworkWatcherRG -StorageId $storageAccountID -TargetResourceId $VNet.Id -FormatVersion 2 -EnableRetention $true -RetentionPolicyDays 7
+            if ( $ret.TargetResourceId.toLower().length -ne 0 -AND $ret.Enabled ) {
+                Write-Output "Success: VNet flow logs are enabled with Name: $($ret.Name)"
+            }
+            else {
+                Write-Error "Fail: Could not enable VNet flow logs"
+            }
         }
         Write-Output ""
     }
 }
 
-Write-Output ""
-Write-Output ""
 Write-Output "Please provide Kentik with the following:"
 Write-Output "`tSubscription ID:            $subscriptionID"
 Write-Output "`tResource Group:             $resourceGroup"


### PR DESCRIPTION
Replaces azure nsg flow logs with vnet flow logs, ref https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-overview

- simplifies some of the validation conditionals to make the script perform faster while requiring fewer additional package installations (ie NuGet)
- removes enablement and check for the `AllowNetworkWatcher` feature as this is not a requirement per MS [doc](https://learn.microsoft.com/en-us/azure/network-watcher/vnet-flow-logs-powershell#prerequisites). tested running the powershell script in a brand new sub without the feature enabled and successfully created vnet flow logs as expected.
- tested running powershell env locally with a brand new sub. 
- successfully validated each step of the script performed properly with the introduced changes.
- validated that if a storage account did not exist it would create a new one per the provided SA name and if one already existed it would use the existing SA.
- validated that vnet flow logs would be created for each vnet hosted in the specified RG with the following scenarios: 3x vnets in 1 RG where 2x vnets already had flow logs setup and 1x vnet did not. It would skip over the existing vnet flow logs and only create a new flow log for the 1x vnet that did not have it setup.
